### PR TITLE
Git Ignore update to remove binary and implement StackObject template using string slices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-./generator
+generator
 
 *.out
 coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,16 @@
 # limitations under the License.
 
 # Test will run the tests
-test:
+test: vet fmt
 	go test ./... -coverprofile coverage.txt -covermode atomic
+
+# Run go fmt against code
+fmt:
+	go fmt ./...
+
+# Run go vet against code
+vet:
+	go vet ./...
 
 # Build will build the go binary
 build:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,12 +17,16 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
+	"go.awsctrl.io/generator/apis/generator/v1alpha1"
+	"sigs.k8s.io/yaml"
 )
 
 var cfgFile string
+var cfg v1alpha1.Config
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -44,5 +48,22 @@ func Execute() {
 }
 
 func init() {
+	cobra.OnInitialize(initConfig)
+
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "f", "awsctrl-generator.yaml", "config file (default is awsctrl-generator.yaml)")
+	rootCmd.MarkFlagRequired("config")
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func initConfig() {
+	yamlFile, err := ioutil.ReadFile(cfgFile)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	err = yaml.Unmarshal(yamlFile, &cfg)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -47,121 +47,8 @@ var runCmd = &cobra.Command{
 			},
 		}
 
-		groupincludes := []string{
-			// "cloudformation",
-			// // remove from this list
-			// "apigateway",
-			// "amazonmq",
-			// "amplify",
-			// "apigatewayv2",
-			// "applicationautoscaling",
-			// "appmesh",
-			// "appstream",
-			// "appsync",
-			// "ask",
-			// "athena",
-			// "autoscaling",
-			// "autoscalingplans",
-			// "backup",
-			// "batch",
-			// "budgets",
-			// "certificatemanager",
-			// "cloud9",
-			// "cloudformation",
-			// "cloudfront",
-			// "cloudtrail",
-			// "cloudwatch",
-			// "codebuild",
-			// "codecommit",
-			// "codedeploy",
-			// "codepipeline",
-			// "codestar",
-			// "codestarnotifications",
-			// "cognito",
-			// "config",
-			// "datapipeline",
-			// "dax",
-			// "directoryservice",
-			// "dlm",
-			// "dms",
-			// "docdb",
-			// "dynamodb",
-			// "ec2",
-			// "ecr",
-			// "ecs",
-			// "efs",
-			// "eks",
-			// "elasticache",
-			// "elasticbeanstalk",
-			// "elasticloadbalancing",
-			// "elasticloadbalancingv2",
-			// "elasticsearch",
-			// "emr",
-			// "events",
-			// "fsx",
-			// "gamelift",
-			// "glue",
-			// "greengrass",
-			// "guardduty",
-			// "iam",
-			// "inspector",
-			// "iot",
-			// "iot1click",
-			// "iotanalytics",
-			// "iotevents",
-			// "iotthingsgraph",
-			// "kinesis",
-			// "kinesisanalytics",
-			// "kinesisanalyticsv2",
-			// "kinesisfirehose",
-			// "kms",
-			// "lakeformation",
-			// "lambda",
-			// "logs",
-			// "managedblockchain",
-			// "mediaconvert",
-			// "medialive",
-			// "mediastore",
-			// "meta",
-			// "msk",
-			// "neptune",
-			// "opsworks",
-			// "opsworkscm",
-			// "pinpoint",
-			// "pinpointemail",
-			// "qldb",
-			// "ram",
-			// "rds",
-			// "redshift",
-			// "robomaker",
-			// "route53",
-			// "route53resolver",
-			// "s3",
-			// "sagemaker",
-			// "sdb",
-			// "secretsmanager",
-			// "securityhub",
-			// "self",
-			// "servicecatalog",
-			// "servicediscovery",
-			// "ses",
-			// "sns",
-			// "sqs",
-			// "ssm",
-			// "stepfunctions",
-			// "transfer",
-			// "waf",
-			// "wafregional",
-			// "workspaces",
-		}
-
-		resourceincludes := []string{
-			"apigateway:account",
-			"apigateway:deployment",
-		}
-
 		builder := api.New(fs, options)
-		spec := cfnspec.New(groupincludes, resourceincludes)
+		spec := cfnspec.New(cfg.Spec.Groups, cfg.Spec.Resources)
 
 		if err := spec.Parse(); err != nil {
 			fmt.Println(err)
@@ -179,8 +66,8 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(runCmd)
-
 	runCmd.Flags().StringVarP(&boilerplatePath, "boilerplate-path", "b", "./hack/boilerplate.go.txt", "Path to the boilerplate header.")
 	runCmd.Flags().StringVarP(&projectPath, "project-path", "p", "./PROJECT", "Path to the project file.")
+
+	rootCmd.AddCommand(runCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,9 @@ require (
 	go.hein.dev/go-version v0.1.0
 	golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e // indirect
 	golang.org/x/tools v0.0.0-20190812233024-afc3694995b6
-	gopkg.in/yaml.v2 v2.2.7 // indirect
+	gopkg.in/yaml.v2 v2.2.7
 	k8s.io/apimachinery v0.0.0-20191115015347-3c7067801da2
 	sigs.k8s.io/controller-runtime v0.3.0
 	sigs.k8s.io/kubebuilder v1.0.8
+	sigs.k8s.io/yaml v1.1.0
 )

--- a/main.go
+++ b/main.go
@@ -18,5 +18,5 @@ package main
 import "go.awsctrl.io/generator/cmd"
 
 func main() {
-  cmd.Execute()
+	cmd.Execute()
 }

--- a/pkg/cfnspec/cfnspec.go
+++ b/pkg/cfnspec/cfnspec.go
@@ -119,7 +119,7 @@ func (in *cfnspec) GenerateResources() error {
 
 	// Resources
 	for resourcename, cloudformationresource := range in.GetSpecification().ResourceTypes {
-		newresource := newResource(strings.Split(resourcename, "::"), cloudformationresource)
+		newresource := newResource(resourcename, cloudformationresource)
 
 		for name, property := range cloudformationresource.Properties {
 			properties := newresource.ResourceType.GetProperties()
@@ -200,7 +200,9 @@ func (in *cfnspec) SetResources(resources []resource.Resource) error {
 	return nil
 }
 
-func newResource(nameslice []string, cfnresource CloudFormationResource) *resource.Resource {
+func newResource(resourcename string, cfnresource CloudFormationResource) *resource.Resource {
+	nameslice := strings.Split(resourcename, "::")
+
 	return &resource.Resource{
 		Resource: kbresource.Resource{
 			Namespaced: true,
@@ -208,6 +210,7 @@ func newResource(nameslice []string, cfnresource CloudFormationResource) *resour
 			Version:    "v1alpha1",
 			Kind:       nameslice[len(nameslice)-1],
 		},
+		ResourceName:  resourcename,
 		ResourceType:  newBaseResource(cfnresource),
 		PropertyTypes: map[string]resource.ResourceType{},
 	}

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -26,6 +26,9 @@ import (
 type Resource struct {
 	kbresource.Resource
 
+	// ResourceName returns the CFN Name
+	ResourceName string
+
 	// ResourceType maps all the attributes on the resource
 	ResourceType ResourceType
 
@@ -67,8 +70,11 @@ type Property interface {
 	// GetGoType returns the golang type
 	GetGoType(string) string
 
-	// IsParameter will make a property a parameter
+	// IsParameter will return if the property is a parameter
 	IsParameter() bool
+
+	// IsList will return if the property is a list
+	IsList() bool
 
 	// GetDefault returns default values for params
 	GetDefault() string

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -24,9 +24,9 @@ import (
 	"html/template"
 	"path/filepath"
 
+	"github.com/spf13/afero"
 	"go.awsctrl.io/generator/pkg/input"
 	"go.awsctrl.io/generator/pkg/resource"
-	"github.com/spf13/afero"
 	"golang.org/x/tools/imports"
 
 	"github.com/Masterminds/sprig"
@@ -107,6 +107,7 @@ func funcMap() template.FuncMap {
 	funcs := map[string]interface{}{
 		"lowerfirst": lowerfirst,
 		"pluralize":  flect.Pluralize,
+		"noescape":   noescape,
 	}
 
 	return funcs
@@ -116,4 +117,8 @@ func lowerfirst(str string) string {
 	a := []rune(str)
 	a[0] = unicode.ToLower(a[0])
 	return string(a)
+}
+
+func noescape(str string) template.HTML {
+	return template.HTML(str)
 }


### PR DESCRIPTION
This removes the `generator` binary from the root and adds parsing for string slices, still need to work through other objects.