### PR TITLE
Refactor, remove unused code, configure apigateway attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,3 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
-notifications:
-  webhooks: https://www.travisbuddy.com/

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,6 +24,7 @@ import (
 	"go.awsctrl.io/generator/pkg/controller"
 	"go.awsctrl.io/generator/pkg/controllermanager"
 	"go.awsctrl.io/generator/pkg/group"
+	"go.awsctrl.io/generator/pkg/kustomize"
 	"go.awsctrl.io/generator/pkg/stackobject"
 	"go.awsctrl.io/generator/pkg/types"
 
@@ -63,6 +64,7 @@ func (a *API) Build(r *resource.Resource, rs []resource.Resource) (err error) {
 		&stackobject.StackObject{Resource: r, Input: *in, Resources: rs},
 		&controller.Controller{Resource: r, Input: *in, Resources: rs},
 		&controllermanager.ControllerManager{Resource: r, Input: *in, Resources: rs},
+		&kustomize.CRD{Resource: r, Input: *in, Resources: rs},
 	}
 
 	s := scaffold.New(a.fs, r)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -45,8 +45,8 @@ func TestAPI_Build(t *testing.T) {
 			ShortNames: []string{"repo"},
 		},
 		ResourceType: &resource.BaseResource{
-			Attributes: map[string]map[string]string{
-				"Arn": map[string]string{
+			Attributes: map[string]interface{}{
+				"Arn": map[string]interface{}{
 					"PrimitiveType": "string",
 				},
 			},
@@ -54,7 +54,7 @@ func TestAPI_Build(t *testing.T) {
 			Properties: map[string]resource.Property{
 				"RepositoryName": &resource.BaseProperty{
 					Documentation: "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html#cfn-ecr-repository-repositoryname",
-					Type:          "string",
+					Type:          "String",
 					Required:      false,
 					UpdateType:    resource.ImmutableType,
 				},
@@ -71,13 +71,13 @@ func TestAPI_Build(t *testing.T) {
 				Properties: map[string]resource.Property{
 					"LifecyclePolicyText": &resource.BaseProperty{
 						Documentation: "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecr-repository-lifecyclepolicy.html#cfn-ecr-repository-lifecyclepolicy-lifecyclepolicytext",
-						Type:          "string",
+						Type:          "String",
 						Required:      false,
 						UpdateType:    resource.MutableType,
 					},
 					"RegistryId": &resource.BaseProperty{
 						Documentation: "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecr-repository-lifecyclepolicy.html#cfn-ecr-repository-lifecyclepolicy-registryid",
-						Type:          "string",
+						Type:          "String",
 						Required:      false,
 						UpdateType:    resource.MutableType,
 					},

--- a/pkg/cfnspec/cfnspec.go
+++ b/pkg/cfnspec/cfnspec.go
@@ -128,6 +128,8 @@ func (in *cfnspec) GenerateResources() error {
 
 			newresource.ResourceType.SetProperties(properties)
 
+			newresource.ResourceType.SetAttributes(newresource.ResourceType.GetAttributes())
+
 		}
 		resources = append(resources, *newresource)
 	}
@@ -217,9 +219,14 @@ func newResource(resourcename string, cfnresource CloudFormationResource) *resou
 }
 
 func newBaseResource(cfnresource CloudFormationResource) *resource.BaseResource {
+	attrs := map[string]interface{}{}
+	for name, prop := range cfnresource.Attributes {
+		attrs[name] = &prop
+	}
 	return &resource.BaseResource{
 		Properties:    map[string]resource.Property{},
 		Documentation: cfnresource.Documentation,
+		Attributes:    attrs,
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -49,8 +49,8 @@ func (in *Controller) GetInput() input.Input {
 }
 
 // Validate validates the values
-func (g *Controller) Validate() error {
-	return g.Resource.Validate()
+func (c *Controller) Validate() error {
+	return c.Resource.Validate()
 }
 
 const controllerTemplate = `{{ .Boilerplate }}
@@ -64,6 +64,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,14 +74,10 @@ import (
 	"go.awsctrl.io/manager/controllers/generic"
 )
 
-var (
-	// APIGVStr returns the group version for the resource
-	APIGVStr = v1alpha1.GroupVersion.String()
-)
-
 // {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object
 type {{ .Resource.Kind }}Reconciler struct {
 	client.Client
+	dynamic.Interface
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }
@@ -108,7 +105,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(req ctrl.Request) (ctrl.Resul
 	}
 
 	var cfncontroller generic.Generic
-	if cfncontroller, err = generic.New(r.Client, r.Scheme); err != nil {
+	if cfncontroller, err = generic.New(r.Client, r.Interface, r.Scheme); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/controllermanager/controllermanager.go
+++ b/pkg/controllermanager/controllermanager.go
@@ -70,14 +70,14 @@ package controllermanager
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	{{ range $group, $version := .Groups }}
 	{{ $group }}{{ $version }} "go.awsctrl.io/manager/apis/{{ $group }}/{{ $version }}"
 	"go.awsctrl.io/manager/controllers/{{ $group }}"
 	{{ end }}
-
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddAllSchemes will configure all the schemes
@@ -89,11 +89,12 @@ func AddAllSchemes(scheme *runtime.Scheme) error {
 }
 
 // SetupControllers will configure your manager with all controllers
-func SetupControllers(mgr manager.Manager) (reconciler string, err error) {
+func SetupControllers(mgr manager.Manager, dynamicClient dynamic.Interface) (reconciler string, err error) {
 
 	{{ range $resource := .Resources }}
 	if err = (&{{ $resource.Resource.Group }}.{{ $resource.Resource.Kind }}Reconciler{
 		Client: mgr.GetClient(),
+		Interface: dynamicClient,
 		Log:    ctrl.Log.WithName("controllers").WithName("{{ $resource.Resource.Group }}").WithName("{{ $resource.Resource.Kind | lower }}"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {

--- a/pkg/group/group.go
+++ b/pkg/group/group.go
@@ -56,7 +56,7 @@ const groupTemplate = `{{ .Boilerplate }}
 // Package {{ .Resource.Version }} contains API Schema definitions for the {{ .Resource.Group }} {{.Resource.Version}} API group
 // +kubebuilder:object:generate=true
 // +groupName={{ .Resource.Group }}.{{ .Domain }}
-package {{ .Resource.Version }}
+package {{ .Resource.Version }} // import "go.{{ .Domain }}/manager/apis/{{ .Resource.Group }}/{{ .Resource.Version }}"
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2019 AWS Controller authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kustomize configures the kustomize file
+package kustomize
+
+import (
+	"path/filepath"
+
+	"go.awsctrl.io/generator/pkg/input"
+	"go.awsctrl.io/generator/pkg/resource"
+)
+
+var _ input.File = &CRD{}
+
+// CRD scaffolds the controllers/manager/manager.go
+type CRD struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	// Resources stores the entire list of resources
+	Resources []resource.Resource
+}
+
+// GetInput implements input.File
+func (in *CRD) GetInput() input.Input {
+	if in.Path == "" {
+		in.Path = filepath.Join("config", "crd", "kustomization.yaml")
+	}
+
+	in.TemplateBody = crdTemplate
+	return in.Input
+}
+
+// Validate validates the values
+func (in *CRD) Validate() error {
+	return in.Resource.Validate()
+}
+
+const crdTemplate = `# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/self.awsctrl.io_configs.yaml
+- bases/cloudformation.awsctrl.io_stacks.yaml
+{{- range $resource := .Resources }}
+- bases/{{ $resource.Resource.Group }}.awsctrl.io_{{ $resource.Resource.Kind | lower | pluralize }}.yaml{{ end }}
+# +kubebuilder:scaffold:crdkustomizeresource
+
+patchesStrategicMerge:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+#- patches/webhook_in_accounts.yaml
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+#- patches/cainjection_in_accounts.yaml
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml
+`

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -48,7 +48,10 @@ type ResourceType interface {
 	SetProperties(map[string]Property)
 
 	// GetAttributes returns attributes
-	GetAttributes() map[string]map[string]string
+	GetAttributes() map[string]interface{}
+
+	// SetAttributes edits all attributes
+	SetAttributes(map[string]interface{})
 }
 
 // UpdateType defines enum of param types
@@ -70,11 +73,20 @@ type Property interface {
 	// GetGoType returns the golang type
 	GetGoType(string) string
 
+	// GetSingularGoType returns the golang type
+	GetSingularGoType(string) string
+
 	// IsParameter will return if the property is a parameter
 	IsParameter() bool
 
+	// IsListParameter will return if the list type is parameterable
+	IsListParameter() bool
+
 	// IsList will return if the property is a list
 	IsList() bool
+
+	// IsMap will return if the property is a map
+	IsMap() bool
 
 	// GetDefault returns default values for params
 	GetDefault() string
@@ -93,7 +105,7 @@ type Property interface {
 type BaseResource struct {
 	mux           sync.Mutex
 	Documentation string
-	Attributes    map[string]map[string]string
+	Attributes    map[string]interface{}
 	Properties    map[string]Property
 }
 


### PR DESCRIPTION
This is a big update, it adds full support for `metav1alpha1.ObjectReference` to create dependency trees for separate components. It will allow you to use any `Output` from another Stack in the same namespace. There are some security implications that need to be researched more around blocking someone from using an out of namespace output.

This adds better support for Maps, and nested params.

Signed-off-by: Chris Hein <me@chrishein.com>