### PR TITLE
Adding Refs to ObjRefs + e2e + yaml

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,19 +20,23 @@ import (
 	"github.com/spf13/afero"
 
 	kbinput "sigs.k8s.io/kubebuilder/pkg/scaffold/input"
-
+	
 	"go.awsctrl.io/generator/pkg/controller"
 	"go.awsctrl.io/generator/pkg/controllermanager"
+	"go.awsctrl.io/generator/pkg/e2e"
 	"go.awsctrl.io/generator/pkg/group"
 	"go.awsctrl.io/generator/pkg/kustomize"
 	"go.awsctrl.io/generator/pkg/stackobject"
 	"go.awsctrl.io/generator/pkg/types"
+	"go.awsctrl.io/generator/pkg/yaml"
+	"go.awsctrl.io/generator/pkg/project"
 
 	"go.awsctrl.io/generator/pkg/input"
 	"go.awsctrl.io/generator/pkg/resource"
 	"go.awsctrl.io/generator/pkg/scaffold"
 )
 
+// API contains the bits for the builder
 type API struct {
 	fs afero.Fs
 
@@ -63,11 +67,15 @@ func (a *API) Build(r *resource.Resource, rs []resource.Resource) (err error) {
 		&group.Group{Resource: r, Input: *in, Resources: rs},
 		&stackobject.StackObject{Resource: r, Input: *in, Resources: rs},
 		&controller.Controller{Resource: r, Input: *in, Resources: rs},
-		&controllermanager.ControllerManager{Resource: r, Input: *in, Resources: rs},
 		&kustomize.CRD{Resource: r, Input: *in, Resources: rs},
+		&yaml.YAML{Resource: r, Input: *in, Resources: rs},
+		&e2e.E2E{Resource: r, Input: *in, Resources: rs},
+		&e2e.Suite{Resource: r, Input: *in, Resources: rs},
+		&controllermanager.ControllerManager{Resource: r, Input: *in, Resources: rs},
+		&project.Project{Resource: r, Input: *in, Resources: rs},
 	}
 
-	s := scaffold.New(a.fs, r)
+	s := scaffold.New(a.fs)
 
 	if err := s.Execute(files...); err != nil {
 		return err

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -48,9 +48,12 @@ func (in *Controller) GetInput() input.Input {
 	return in.Input
 }
 
+// ShouldOverride will tell the scaffolder to override existing files
+func (in *Controller) ShouldOverride() bool { return true }
+
 // Validate validates the values
-func (c *Controller) Validate() error {
-	return c.Resource.Validate()
+func (in *Controller) Validate() error {
+	return in.Resource.Validate()
 }
 
 const controllerTemplate = `{{ .Boilerplate }}

--- a/pkg/controllermanager/controllermanager.go
+++ b/pkg/controllermanager/controllermanager.go
@@ -58,6 +58,9 @@ func (in *ControllerManager) GetInput() input.Input {
 	return in.Input
 }
 
+// ShouldOverride will tell the scaffolder to override existing files
+func (in *ControllerManager) ShouldOverride() bool { return true }
+
 // Validate validates the values
 func (in *ControllerManager) Validate() error {
 	return in.Resource.Validate()

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -1,0 +1,169 @@
+/*
+Copyright © 2019 AWS Controller authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package e2e creates e2e tests files
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+
+	"go.awsctrl.io/generator/pkg/input"
+	"go.awsctrl.io/generator/pkg/resource"
+)
+
+var _ input.File = &E2E{}
+
+// E2E scaffolds the e2e/group/kind_test.go
+type E2E struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	// Resources stores the entire list of resources
+	Resources []resource.Resource
+}
+
+// GetInput implements input.File
+func (in *E2E) GetInput() input.Input {
+	if in.Path == "" {
+		in.Path = filepath.Join("e2e", strings.ToLower(in.Resource.Group), strings.ToLower(in.Resource.Kind)+"_test.go")
+	}
+
+	in.TemplateBody = e2eTemplate
+	return in.Input
+}
+
+// ShouldOverride will tell the scaffolder to override existing files
+func (in *E2E) ShouldOverride() bool { return false }
+
+const e2eTemplate = `{{ .Boilerplate }}
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	{{ .Resource.Group | lower }}v1alpha1 "go.awsctrl.io/manager/apis/{{ .Resource.Group | lower }}/v1alpha1"
+	cloudformationv1alpha1 "go.awsctrl.io/manager/apis/cloudformation/v1alpha1"
+
+	metav1alpha1 "go.awsctrl.io/manager/apis/meta/v1alpha1"
+)
+
+// Run{{ .Resource.Kind }}Specs allows all instance E2E tests to run
+var _ = Describe("Run {{ .Resource.Group }} {{ .Resource.Kind }} Controller", func() {
+
+	Context("Without {{ .Resource.Kind }}{} existing", func() {
+
+		It("Should create {{ .Resource.Group | lower }}.{{ .Resource.Kind }}{}", func() {
+			var stackID string
+			var stackName string
+			var stack *cloudformationv1alpha1.Stack
+			k8sclient := k8smanager.GetClient()
+			Expect(k8sclient).ToNot(BeNil())
+
+			instance := &{{ .Resource.Group | lower }}v1alpha1.{{ .Resource.Kind }}{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "sample-{{ .Resource.Kind | lower }}-",
+					Namespace:    podnamespace,
+				},
+				Spec: {{ .Resource.Group | lower }}v1alpha1.{{ .Resource.Kind }}Spec{},
+			}
+			By("Creating new {{ .Resource.Group }} {{ .Resource.Kind }}")
+			Expect(k8sclient.Create(context.Background(), instance)).Should(Succeed())
+
+			key := types.NamespacedName{
+				Name:      instance.GetName(),
+				Namespace: podnamespace,
+			}
+
+			By("Expecting CreateComplete")
+			Eventually(func() bool {
+				By("Getting latest {{ .Resource.Group }} {{ .Resource.Kind }}")
+				instance = &{{ .Resource.Group | lower }}v1alpha1.{{ .Resource.Kind }}{}
+				err := k8sclient.Get(context.Background(), key, instance)
+				if err != nil {
+					return false
+				}
+
+				stackID = instance.GetStackID()
+				stackName = instance.GetStackName()
+
+				return instance.Status.Status == metav1alpha1.CreateCompleteStatus ||
+					(os.Getenv("USE_AWS_CLIENT") != "true" && instance.Status.Status != "")
+			}, timeout, interval).Should(BeTrue())
+
+			By("Checking object OwnerShip")
+			Eventually(func() bool {
+				stackkey := types.NamespacedName{
+					Name:      stackName,
+					Namespace: key.Namespace,
+				}
+
+				stack = &cloudformationv1alpha1.Stack{}
+				err := k8sclient.Get(context.Background(), stackkey, stack)
+				if err != nil {
+					return false
+				}
+
+				expectedOwnerReference := v1.OwnerReference{
+					Kind:       instance.Kind,
+					APIVersion: instance.APIVersion,
+					UID:        instance.UID,
+					Name:       instance.Name,
+				}
+
+				ownerrefs := stack.GetOwnerReferences()
+				Expect(len(ownerrefs)).To(Equal(1))
+
+				return ownerrefs[0].Name == expectedOwnerReference.Name
+			}, timeout, interval).Should(BeTrue())
+
+			By("Deleting {{ .Resource.Group }} {{ .Resource.Kind }}")
+			Expect(k8sclient.Delete(context.Background(), instance)).Should(Succeed())
+
+			By("Deleting {{ .Resource.Kind }} Stack")
+			Expect(k8sclient.Delete(context.Background(), stack)).Should(Succeed())
+
+			By("Expecting metav1alpha1.DeleteCompleteStatus")
+			Eventually(func() bool {
+				if os.Getenv("USE_AWS_CLIENT") != "true" {
+					return true
+				}
+
+				output, err := awsclient.GetClient("us-west-2").DescribeStacks(&cloudformation.DescribeStacksInput{StackName: aws.String(stackID)})
+				Expect(err).To(BeNil())
+				stackoutput := output.Stacks[0].StackStatus
+				return *stackoutput == "DELETE_COMPLETE"
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+})
+
+`

--- a/pkg/e2e/suite.go
+++ b/pkg/e2e/suite.go
@@ -1,0 +1,259 @@
+/*
+Copyright © 2019 AWS Controller authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package e2e creates e2e tests files
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+
+	"go.awsctrl.io/generator/pkg/input"
+	"go.awsctrl.io/generator/pkg/resource"
+)
+
+var _ input.File = &Suite{}
+
+// Suite scaffolds the e2e/group/suite_test.go
+type Suite struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	// Resources stores the entire list of resources
+	Resources []resource.Resource
+}
+
+// GetInput implements input.File
+func (in *Suite) GetInput() input.Input {
+	if in.Path == "" {
+		in.Path = filepath.Join("e2e", strings.ToLower(in.Resource.Group), "suite_test.go")
+	}
+
+	in.TemplateBody = suiteTemplate
+	return in.Input
+}
+
+// ShouldOverride will tell the scaffolder to override existing files
+func (in *Suite) ShouldOverride() bool { return false }
+
+const suiteTemplate = `{{ .Boilerplate }}
+
+package e2e_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"go.awsctrl.io/manager/aws"
+	"go.awsctrl.io/manager/controllers/cloudformation"
+	"go.awsctrl.io/manager/controllers/controllermanager"
+	"go.awsctrl.io/manager/controllers/self"
+	"go.awsctrl.io/manager/testutils"
+	"go.awsctrl.io/manager/token"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cloudformationv1alpha1 "go.awsctrl.io/manager/apis/cloudformation/v1alpha1"
+	metav1alpha1 "go.awsctrl.io/manager/apis/meta/v1alpha1"
+	selfv1alpha1 "go.awsctrl.io/manager/apis/self/v1alpha1"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	cfg          *rest.Config
+	k8sclient    client.Client
+	k8smanager   ctrl.Manager
+	testenv      *envtest.Environment
+	awsclient    aws.AWS
+	configname   string = "config"
+	podnamespace string = "default"
+	timeout             = time.Second * 300
+	interval            = time.Second * 1
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{envtest.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	By("bootstrapping test environment")
+	testenv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	var err error
+	cfg, err = testenv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	err = scheme.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = selfv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = cloudformationv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = controllermanager.AddAllSchemes(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8smanager, err = ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	if os.Getenv("USE_AWS_CLIENT") == "true" {
+		awsclient = aws.New()
+	} else {
+		awsclient = testutils.NewAWS()
+	}
+
+	err = (&self.ConfigReconciler{
+		Client:       k8smanager.GetClient(),
+		Log:          ctrl.Log.WithName("controllers").WithName("self").WithName("config"),
+		Scheme:       k8smanager.GetScheme(),
+		ConfigName:   configname,
+		PodNamespace: podnamespace,
+		AWSClient:    awsclient,
+	}).SetupWithManager(k8smanager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&cloudformation.StackReconciler{
+		Client:       k8smanager.GetClient(),
+		Log:          ctrl.Log.WithName("controllers").WithName("cloudformation").WithName("stack"),
+		Scheme:       k8smanager.GetScheme(),
+		ConfigName:   configname,
+		PodNamespace: podnamespace,
+		AWSClient:    awsclient,
+		TokenClient:  token.New(),
+	}).SetupWithManager(k8smanager)
+	Expect(err).ToNot(HaveOccurred())
+
+	var dynclient dynamic.Interface
+	if os.Getenv("USE_EXISTING_CLUSTER") == "true" {
+		dynclient, err = dynamic.NewForConfig(k8smanager.GetConfig())
+		Expect(err).ToNot(HaveOccurred())
+	} else {
+		dynclient = fake.NewSimpleDynamicClient(scheme.Scheme, []runtime.Object{}...)
+	}
+
+	_, err = controllermanager.SetupControllers(k8smanager, dynclient)
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		err = k8smanager.Start(ctrl.SetupSignalHandler())
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	k8sclient = k8smanager.GetClient()
+	Expect(k8sclient).ToNot(BeNil())
+
+	configkey := types.NamespacedName{
+		Name:      configname,
+		Namespace: podnamespace,
+	}
+
+	config := &selfv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configkey.Name,
+			Namespace: configkey.Namespace,
+		},
+		Spec: selfv1alpha1.ConfigSpec{
+			ClusterName: "test-cluster",
+			Resources:   []string{},
+			AWS: selfv1alpha1.ConfigAWS{
+				DefaultRegion:    "us-west-2",
+				AccountID:        os.Getenv("AWS_ACCOUNT_ID"),
+				SupportedRegions: []string{"us-west-2"},
+			},
+		},
+	}
+	Expect(k8sclient.Create(context.Background(), config)).Should(Succeed())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	Eventually(func() bool {
+		stackList := cloudformationv1alpha1.StackList{}
+		if err := k8sclient.List(context.Background(), &stackList); err != nil {
+			return false
+		}
+
+		if len(stackList.Items) == 0 {
+			return true
+		}
+
+		for _, stack := range stackList.Items {
+			if os.Getenv("USE_AWS_CLIENT") == "true" {
+				awsclient.SetClient("us-west-2", testutils.NewCFN("DELETE_COMPLETE"))
+			}
+
+			if stack.Status.Status == metav1alpha1.DeleteInProgressStatus {
+				continue
+			}
+
+			if err := k8sclient.Delete(context.Background(), &stack); err != nil {
+				return false
+			}
+		}
+		return false
+	}, (time.Second * 60), time.Second*1).Should(BeTrue())
+
+	config := &selfv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configname,
+			Namespace: podnamespace,
+		},
+	}
+
+	Expect(k8sclient.Delete(context.Background(), config)).Should(Succeed())
+
+	gexec.KillAndWait(5 * time.Second)
+	err := testenv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})`

--- a/pkg/group/group.go
+++ b/pkg/group/group.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package types will generate the apis/<service>/<resource>_types.go
+// Package group will generate the apis/<service>/<resource>_types.go
 package group
 
 import (
@@ -46,9 +46,12 @@ func (in *Group) GetInput() input.Input {
 	return in.Input
 }
 
+// ShouldOverride will tell the scaffolder to override existing files
+func (in *Group) ShouldOverride() bool { return true }
+
 // Validate validates the values
-func (g *Group) Validate() error {
-	return g.Resource.Validate()
+func (in *Group) Validate() error {
+	return in.Resource.Validate()
 }
 
 const groupTemplate = `{{ .Boilerplate }}

--- a/pkg/input/types.go
+++ b/pkg/input/types.go
@@ -24,6 +24,9 @@ import (
 type File interface {
 	// returns the file input for the file generator
 	GetInput() Input
+
+	// Override tells the scaffolder if it should overwrite existing files
+	ShouldOverride() bool
 }
 
 // ProjectFile loads project file from kubebuilder

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -47,6 +47,9 @@ func (in *CRD) GetInput() input.Input {
 	return in.Input
 }
 
+// ShouldOverride will tell the scaffolder to override existing files
+func (in *CRD) ShouldOverride() bool { return true }
+
 // Validate validates the values
 func (in *CRD) Validate() error {
 	return in.Resource.Validate()

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,98 @@
+/*
+Copyright © 2019 AWS Controller authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package project configures the central controller manager
+package project
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/yaml"
+
+	"go.awsctrl.io/generator/pkg/input"
+	"go.awsctrl.io/generator/pkg/resource"
+)
+
+var _ input.File = &Project{}
+
+// Project scaffolds the controllers/manager/manager.go
+type Project struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	// Resources stores the entire list of resources
+	Resources []resource.Resource
+
+	// Groups lists all
+	Groups map[string]string
+}
+
+// File is deserialized into a PROJECT file
+type File struct {
+	Version string `json:"version,omitempty"`
+	Domain string `json:"domain,omitempty"`
+	Repo string `json:"repo,omitempty"`
+	Multigroup bool `json:"multigroup,omitempty"`
+	Resources []Resource `json:"resources,omitempty"`
+}
+
+// Resource contains information about scaffolded resources.
+type Resource struct {
+	Group   string `json:"group,omitempty"`
+	Version string `json:"version,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+}
+
+// GetInput implements input.File
+func (in *Project) GetInput() input.Input {
+	if in.Path == "" {
+		in.Path = filepath.Join("PROJECT")
+	}
+
+	resources := []Resource{}
+	for _, resource := range in.Resources {
+		r := Resource{
+			Group: resource.Group,
+			Version: resource.Version,
+			Kind: resource.Kind,
+		}
+
+		resources = append(resources, r)
+	}
+
+	pfile := File{
+		Version: "2",
+		Domain:  "awsctrl.io",
+		Repo:    "awsctrl.io",
+		Multigroup: true,
+		Resources: resources,
+	}
+
+	data, _ := yaml.Marshal(&pfile)
+
+	in.TemplateBody = string(data)
+	return in.Input
+}
+
+// ShouldOverride will tell the scaffolder to override existing files
+func (in *Project) ShouldOverride() bool { return true }
+
+// Validate validates the values
+func (in *Project) Validate() error {
+	return in.Resource.Validate()
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -30,12 +30,12 @@ func IdOrArn(name string) bool {
 
 // IsArn checks if it's an Id
 func IsId(name, postfix string) bool {
-	return strings.HasSuffix(name, "Id"+postfix)
+	return strings.HasSuffix(strings.ToLower(name), strings.ToLower("Id"+postfix))
 }
 
 // IsArn checks if it's an Arn
 func IsArn(name, postfix string) bool {
-	return strings.HasSuffix(name, "Arn"+postfix)
+	return strings.HasSuffix(strings.ToLower(name), strings.ToLower("Arn"+postfix))
 }
 
 // TrimIdOrArn will remove the id or arn declaration
@@ -138,6 +138,8 @@ func (in *BaseProperty) IsParameter() bool {
 		return true
 	case "Integer":
 		return true
+	case "Timestamp":
+		return true
 	case "Double":
 		return true
 	case "Boolean":
@@ -205,6 +207,8 @@ func (in *BaseProperty) ConstructGoType(kind string, plural string) string {
 		return "int"
 	case "Double":
 		return "int"
+	case "Timestamp":
+		return "string"
 	case "Boolean":
 		return "bool"
 	case "Map":

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -49,17 +49,20 @@ func (in *Types) GetInput() input.Input {
 	return in.Input
 }
 
+// ShouldOverride will tell the scaffolder to override existing files
+func (in *Types) ShouldOverride() bool { return true }
+
 // GetProperties returns the attributes for all resource types
 func (in *Types) GetProperties(props map[string]resource.Property) string {
 	lines := []string{}
 	for name, property := range props {
 		originalname := name
 		if resource.IdOrArn(originalname) && property.GetType() == "String" {
-			name = resource.TrimIdOrArn(name)
+			name = resource.TrimIdOrArn(name) + "Ref"
 		}
 
 		if resource.IdsOrArns(originalname) && property.GetItemType() == "String" {
-			name = resource.TrimIdsOrArns(name)
+			name = resource.TrimIdsOrArns(name) + "Refs"
 		}
 
 		// TODO(christopherhein) implement tags
@@ -69,7 +72,7 @@ func (in *Types) GetProperties(props map[string]resource.Property) string {
 		}
 		lines = appendstrf(lines, `// %v %v`, name, property.GetDocumentation())
 		required := ""
-		if !property.GetRequired() {
+		if !property.GetRequired() { //|| originalname != in.Resource.Kind+"Name" {
 			required = ",omitempty"
 		}
 		param := ""

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2019 AWS Controller authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package yaml will generate the apis/<service>/<resource>_types.go
+package yaml
+
+import (
+	"path/filepath"
+	"strings"
+
+	"go.awsctrl.io/generator/pkg/input"
+	"go.awsctrl.io/generator/pkg/resource"
+)
+
+var _ input.File = &YAML{}
+
+// YAML scaffolds the config/samples/<group>/<version>_<kind>.yaml
+type YAML struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	// Resources stores the entire list of resources
+	Resources []resource.Resource
+}
+
+// GetInput implements input.File
+func (in *YAML) GetInput() input.Input {
+	if in.Path == "" {
+		in.Path = filepath.Join("config", "samples", in.Resource.Group, in.Resource.Version+"_"+strings.ToLower(in.Resource.Kind)+".yaml")
+	}
+	in.TemplateBody = groupTemplate
+	return in.Input
+}
+
+// ShouldOverride will tell the scaffolder to override existing files
+func (in *YAML) ShouldOverride() bool { return false }
+
+// Validate validates the values
+func (in *YAML) Validate() error {
+	return in.Resource.Validate()
+}
+
+const groupTemplate = `apiVersion: {{ .Resource.Group | lower }}.awsctrl.io/{{ .Resource.Version }}
+kind: {{ .Resource.Kind }}
+metadata:
+  name: {{ .Resource.Kind | lower }}-sample
+spec: {}`


### PR DESCRIPTION
This adds support for auto-generating `e2e` and `yaml` files, first it will check if the files exist because these files are modified after they are generated.