### PR TITLE
Adding tags for docs generation

### DIFF
--- a/pkg/group/group.go
+++ b/pkg/group/group.go
@@ -40,7 +40,7 @@ type Group struct {
 // GetInput implements input.File
 func (in *Group) GetInput() input.Input {
 	if in.Path == "" {
-		in.Path = filepath.Join("apis", in.Resource.Group, in.Resource.Version, "groupversion_info.go")
+		in.Path = filepath.Join("apis", in.Resource.Group, in.Resource.Version, "doc.go")
 	}
 	in.TemplateBody = groupTemplate
 	return in.Input

--- a/pkg/stackobject/stackobject.go
+++ b/pkg/stackobject/stackobject.go
@@ -83,7 +83,7 @@ func (in *StackObject) GenerateAttributes() string {
 		lines = appendstrf(lines, `"%v": map[string]interface{}{`, name)
 		if attr.GetType() == "String" || attr.GetType() == "Integer" {
 			lines = appendstrf(lines, `"Value": cloudformation.GetAtt("%v", "%v"),`, in.Resource.Kind, name)
-			lines = appendstrf(lines, `"Export": map[string]interface{}{"Name": in.Name + "%v",},`, name)
+			lines = appendstrf(lines, `"Export": map[string]interface{}{"Name": in.Name + "-%v",},`, name)
 		}
 		// TODO(christopherhein): figure out how to make goformation output join functions
 		// if attr.GetType() == "List" {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -186,6 +186,7 @@ type {{ .Resource.Kind }}Output struct {
 	{{ end }}
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories=aws;{{ .Resource.Group }}


### PR DESCRIPTION
This moves to using `doc.go` and adds `+genclient` so that docs generator works.

Signed-off-by: Chris Hein <me@chrishein.com>