### PR TITLE
Fixing the constant changes in the files based on unordered maps

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,16 +20,16 @@ import (
 	"github.com/spf13/afero"
 
 	kbinput "sigs.k8s.io/kubebuilder/pkg/scaffold/input"
-	
+
 	"go.awsctrl.io/generator/pkg/controller"
 	"go.awsctrl.io/generator/pkg/controllermanager"
 	"go.awsctrl.io/generator/pkg/e2e"
 	"go.awsctrl.io/generator/pkg/group"
 	"go.awsctrl.io/generator/pkg/kustomize"
+	"go.awsctrl.io/generator/pkg/project"
 	"go.awsctrl.io/generator/pkg/stackobject"
 	"go.awsctrl.io/generator/pkg/types"
 	"go.awsctrl.io/generator/pkg/yaml"
-	"go.awsctrl.io/generator/pkg/project"
 
 	"go.awsctrl.io/generator/pkg/input"
 	"go.awsctrl.io/generator/pkg/resource"

--- a/pkg/cfnspec/cfnspec.go
+++ b/pkg/cfnspec/cfnspec.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -114,12 +115,50 @@ func (in *cfnspec) Load() (out []byte, err error) {
 	return ioutil.ReadAll(res.Body)
 }
 
+// Properties    map[string]Property
+// Attributes    map[string]Attribute
+func sortProperties(properties map[string]Property) map[string]Property {
+	keys := make([]string, 0, len(properties))
+	for k := range properties {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	p := map[string]Property{}
+	for _, k := range keys {
+		p[k] = properties[k]
+	}
+	return p
+}
+
+func sortAttributes(attributes map[string]Attribute) map[string]Attribute {
+	keys := make([]string, 0, len(attributes))
+	for k := range attributes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	p := map[string]Attribute{}
+	for _, k := range keys {
+		p[k] = attributes[k]
+	}
+	return p
+}
+
 // GenerateResources will generate the resources for generating files
 func (in *cfnspec) GenerateResources() error {
 	resources := []resource.Resource{}
 
 	// Resources
-	for resourcename, cloudformationresource := range in.GetSpecification().ResourceTypes {
+	resourcetypes := in.GetSpecification().ResourceTypes
+	keys := make([]string, 0, len(resourcetypes))
+	for k := range resourcetypes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, resourcename := range keys {
+		cloudformationresource := resourcetypes[resourcename]
 		newresource := newResource(resourcename, cloudformationresource)
 
 		for name, attribute := range cloudformationresource.Attributes {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -44,11 +44,11 @@ type Project struct {
 
 // File is deserialized into a PROJECT file
 type File struct {
-	Version string `json:"version,omitempty"`
-	Domain string `json:"domain,omitempty"`
-	Repo string `json:"repo,omitempty"`
-	Multigroup bool `json:"multigroup,omitempty"`
-	Resources []Resource `json:"resources,omitempty"`
+	Version    string     `json:"version,omitempty"`
+	Domain     string     `json:"domain,omitempty"`
+	Repo       string     `json:"repo,omitempty"`
+	Multigroup bool       `json:"multigroup,omitempty"`
+	Resources  []Resource `json:"resources,omitempty"`
 }
 
 // Resource contains information about scaffolded resources.
@@ -67,20 +67,20 @@ func (in *Project) GetInput() input.Input {
 	resources := []Resource{}
 	for _, resource := range in.Resources {
 		r := Resource{
-			Group: resource.Group,
+			Group:   resource.Group,
 			Version: resource.Version,
-			Kind: resource.Kind,
+			Kind:    resource.Kind,
 		}
 
 		resources = append(resources, r)
 	}
 
 	pfile := File{
-		Version: "2",
-		Domain:  "awsctrl.io",
-		Repo:    "awsctrl.io",
+		Version:    "2",
+		Domain:     "awsctrl.io",
+		Repo:       "awsctrl.io",
 		Multigroup: true,
-		Resources: resources,
+		Resources:  resources,
 	}
 
 	data, _ := yaml.Marshal(&pfile)

--- a/pkg/stackobject/stackobject.go
+++ b/pkg/stackobject/stackobject.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -54,7 +55,16 @@ func (in *StackObject) GetInput() input.Input {
 func (in *StackObject) GenerateAttributes() string {
 	lines := []string{}
 
-	for name, attr := range in.Resource.ResourceType.GetAttributes() {
+	attributes := in.Resource.ResourceType.GetAttributes()
+
+	keys := make([]string, 0, len(attributes))
+	for k := range attributes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, name := range keys {
+		attr := attributes[name]
 		if attr.GetType() == "List" {
 			continue
 		}
@@ -124,7 +134,14 @@ func (in *StackObject) loopTemplateProperties(lines []string, attrName, paramBas
 	groupLower := strings.ToLower(in.Resource.Group)
 	kind := in.Resource.Kind
 
-	for name, property := range propertyMap {
+	keys := make([]string, 0, len(propertyMap))
+	for k := range propertyMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, name := range keys {
+		property := propertyMap[name]
 		originalname := name
 		if resource.IdOrArn(originalname) && property.GetType() == "String" {
 			name = resource.TrimIdOrArn(name) + "Ref"


### PR DESCRIPTION
Adding sort functions on the keys when looping through the property and resource types from the CloudFormation Resource Specification allows each new resource PR to be the same ordering and allow for easier PR reviews.

Signed-off-by: Chris Hein <me@chrishein.com>