### PR TITLE
Adding Slice building for ObjectRefs

### DIFF
--- a/pkg/stackobject/stackobject.go
+++ b/pkg/stackobject/stackobject.go
@@ -315,6 +315,15 @@ func (in *StackObject) loopTemplateProperties(lines []string, attrName, paramBas
 					lines = appendstrf(lines, `}`)
 					lines = appendblank(lines)
 
+					lines = appendstrf(lines, `%v, err := %v.String(client)`, lowerfirst(originalname), subAttrNameItem)
+					lines = appendstrf(lines, `if err != nil {`)
+					lines = appendstrf(lines, `return "", err`)
+					lines = appendstrf(lines, `}`)
+					lines = appendblank(lines)
+					lines = appendstrf(lines, `if %v != "" {`, lowerfirst(originalname))
+					lines = appendstrf(lines, `%v = append(%v, %v)`, subAttrName, subAttrName, lowerfirst(originalname))
+
+					lines = appendstrf(lines, `}`)
 					lines = appendstrf(lines, `}`)
 					lines = appendblank(lines)
 


### PR DESCRIPTION
Right now if you use a slice with an `ObjectRef` it's not calling the `.String()` to grab the value. This adds support for that, fixing the template generation for `*Ids` and `*Arns`.

Signed-off-by: Chris Hein <me@chrishein.com>