### PR TITLE
Adding blacklisted attributes which require conditionals

### DIFF
--- a/pkg/stackobject/stackobject.go
+++ b/pkg/stackobject/stackobject.go
@@ -51,6 +51,18 @@ func (in *StackObject) GetInput() input.Input {
 	return in.Input
 }
 
+func inBlacklist(attr string, r *resource.Resource) bool {
+	if r.Kind == "DomainName" && r.Group == "apigateway" {
+		switch attr {
+		case "DistributionHostedZoneId":
+			return true
+		case "DistributionDomainName":
+			return true
+		}
+	}
+	return false
+}
+
 // GenerateAttributes will return the templating functions
 func (in *StackObject) GenerateAttributes() string {
 	lines := []string{}
@@ -65,7 +77,7 @@ func (in *StackObject) GenerateAttributes() string {
 
 	for _, name := range keys {
 		attr := attributes[name]
-		if attr.GetType() == "List" {
+		if attr.GetType() == "List" || inBlacklist(name, in.Resource) {
 			continue
 		}
 		lines = appendstrf(lines, `"%v": map[string]interface{}{`, name)


### PR DESCRIPTION
In the process of moving the utility functions set up for this org like:

* git.awsctrl.io
* r.awsctrl.io
* git.awsctrl.io

To a new account and converting all those scripts to dogfooding in https://git.awsctrl.io/org I noticed that `apigateway.DomainNames` had Outputs which wouldn't work without conditional statements causing the controller to have issues.

### Solution

This adds a blacklist of `Outputs`, this could be implemented differently but for now it solves the need.

Signed-off-by: Chris Hein <me@chrishein.com>